### PR TITLE
fix: rolldown-vite compat

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,64 +64,71 @@ export default decode64
 export default function vitePluginArraybuffer(): PluginOption {
   return {
     name: "vite-plugin-arraybuffer",
-    resolveId(id) {
-      if (id === "virtual:decode-64") {
-        return id
-      }
-
-      return
+    resolveId: {
+      filter: {
+        id: /^virtual:decode-64$/,
+      },
+      handler(id) {
+        if (id === "virtual:decode-64") {
+          return id
+        }
+        
+        return
+      },
     },
-    load(id) {
-      if (id === "virtual:decode-64") {
-        return decode64Raw
-      }
-      return
-    },
-    async transform(_src, id) {
-      if (id.endsWith("?arraybuffer")) {
-        const file = id.slice(0, -12)
-        this.addWatchFile(file)
-
-        return {
-          code: `export default new Uint8Array([${new Uint8Array(await promises.readFile(file)).join(",")}]).buffer`,
-          map: { mappings: "" }
+    load: {
+      filter: {
+        id: /(^virtual:decode-64$|\?arraybuffer$|\?uint8array$|\?arraybuffer&base64$|\?uint8array&base64$)/,
+      },
+      async handler(id) {
+        if (id === "virtual:decode-64") {
+          return decode64Raw
         }
-      }
-      if (id.endsWith("?uint8array")) {
-        const file = id.slice(0, -11)
-        this.addWatchFile(file)
+        if (id.endsWith("?arraybuffer")) {
+          const file = id.slice(0, -12)
+          this.addWatchFile(file)
 
-        return {
-          code: `export default new Uint8Array([${new Uint8Array(await promises.readFile(file)).join(",")}])`,
-          map: { mappings: "" }
+          return {
+            code: `export default new Uint8Array([${new Uint8Array(await promises.readFile(file)).join(",")}]).buffer`,
+            map: { mappings: "" }
+          }
         }
-      }
-      if (id.endsWith("?arraybuffer&base64")) {
-        const file = id.slice(0, -19)
-        this.addWatchFile(file)
+        if (id.endsWith("?uint8array")) {
+          const file = id.slice(0, -11)
+          this.addWatchFile(file)
 
-        const buffer = await promises.readFile(file)
-        const b64 = buffer.toString("base64")
-
-        return {
-          code: `import decode64 from 'virtual:decode-64'\nexport default decode64("${b64}").buffer`,
-          map: { mappings: "" }
+          return {
+            code: `export default new Uint8Array([${new Uint8Array(await promises.readFile(file)).join(",")}])`,
+            map: { mappings: "" }
+          }
         }
-      }
-      if (id.endsWith("?uint8array&base64")) {
-        const file = id.slice(0, -18)
-        this.addWatchFile(file)
+        if (id.endsWith("?arraybuffer&base64")) {
+          const file = id.slice(0, -19)
+          this.addWatchFile(file)
 
-        const buffer = await promises.readFile(file)
-        const b64 = buffer.toString("base64")
+          const buffer = await promises.readFile(file)
+          const b64 = buffer.toString("base64")
 
-        return {
-          code: `import decode64 from 'virtual:decode-64'\nexport default decode64("${b64}")`,
-          map: { mappings: "" }
+          return {
+            code: `import decode64 from 'virtual:decode-64'\nexport default decode64("${b64}").buffer`,
+            map: { mappings: "" }
+          }
         }
-      }
+        if (id.endsWith("?uint8array&base64")) {
+          const file = id.slice(0, -18)
+          this.addWatchFile(file)
 
-      return
+          const buffer = await promises.readFile(file)
+          const b64 = buffer.toString("base64")
+
+          return {
+            code: `import decode64 from 'virtual:decode-64'\nexport default decode64("${b64}")`,
+            map: { mappings: "" }
+          }
+        }
+
+        return
+      }
     }
   }
 }


### PR DESCRIPTION
When using Nuxt + Rolldown-vite, the file can't be imported:

```
■  Nuxt build error: Error: Build failed with 1 error:
│
│  [UNLOADABLE_DEPENDENCY] Error: Could not load app/assets/foo.txt?arraybuffer
│     ╭─[ app/app.vue?vue&type=script&setup=true&lang.ts:3:17 ]
│     │
│   3 │ import foo from "~/assets/foo.txt?arraybuffer";
│     │                 ───────────────┬──────────────  
│     │                                ╰──────────────── No such file or directory (os error 2)
│  ───╯
```

This patch fixes this. Ported from https://github.com/typed-sigterm/logic-bingo/commit/6636d136aa1c2fb95c200aa73690c8f037929e1c